### PR TITLE
Fix vnode build error with MSVC in windows system

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/vnode_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/vnode_executor.hpp
@@ -498,7 +498,7 @@ struct experimental_attention_executor : public vnode_executor {
         auto layer_id = static_cast<int>(attr_map["layer_id"]);
         auto rotary_dims = static_cast<int>(attr_map["rotary_dims"]);
         auto rope_type = static_cast<int>(attr_map["rope_type"]);
-        auto num_kv_heads = static_cast<int>(attr_map["num_kv_heads"]);
+        auto num_kv_heads = static_cast<size_t>(attr_map["num_kv_heads"]);
         auto H = static_cast<size_t>(attr_map["n_head"]);
         PlainTensor<RT> rope_q, rope_k, rope_v;
         bool multi_query_is_planar;
@@ -552,8 +552,16 @@ struct experimental_attention_executor : public vnode_executor {
 
         m_query_emb.resize({B, H, L1, S});
 
-        auto present_key = kv_cache.index({{layer_id * 2 + 0}, {0, B}, {0, H / gH}, {0, L0 + L1}, {}});
-        auto present_value = kv_cache.index({{layer_id * 2 + 1}, {0, B}, {0, H / gH}, {0, L0 + L1}, {}});
+        auto present_key = kv_cache.index({{layer_id * 2 + 0},
+                                           {0, static_cast<int>(B)},
+                                           {0, static_cast<int>(H / gH)},
+                                           {0, static_cast<int>(L0 + L1)},
+                                           {}});
+        auto present_value = kv_cache.index({{layer_id * 2 + 1},
+                                             {0, static_cast<int>(B)},
+                                             {0, static_cast<int>(H / gH)},
+                                             {0, static_cast<int>(L0 + L1)},
+                                             {}});
 
         half_rotary_dims = rotary_dims / 2;
 

--- a/src/plugins/intel_cpu/src/nodes/vnode_kernels.hpp
+++ b/src/plugins/intel_cpu/src/nodes/vnode_kernels.hpp
@@ -872,7 +872,7 @@ struct MHA_1Token {
         PROFILE_NEXT(prof, "W*V");
         // attn_w * V
         auto nthr = parallel_get_max_threads();
-        m_temp.resize({nthr, B, q_len, H, S});
+        m_temp.resize({static_cast<size_t>(nthr), B, q_len, H, S});
         // m_attn_w {B, H, q_len, kv_len}
         if (h_each_group_len == 0) {
             parallel_nt_static(nthr, [&](const size_t ithr, const size_t nthr) {
@@ -1230,8 +1230,8 @@ struct generic_attention {
             for (size_t beam = 0; beam < beam_size; beam++) {
                 // the last one is always in right order
                 m_beams({beam, kv_len - 1}) = beam;
-                for (int p = kv_len - 2; p >=0; p--) {
-                    auto batch_id = m_beams({beam, p + 1});
+                for (size_t p = kv_len - 2; p >= 0; p--) {
+                    size_t batch_id = static_cast<size_t>(m_beams({beam, p + 1}));
                     m_beams({beam, p}) = m_beam_idx_tab({batch_id, p + 1});
                 }
             }

--- a/src/plugins/intel_cpu/src/utils/gen_pattern.hpp
+++ b/src/plugins/intel_cpu/src/utils/gen_pattern.hpp
@@ -464,7 +464,7 @@ struct GenPatternNode {
     // 1d const tensor or scalar
     template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, bool>::type = true>
     static std::shared_ptr<Node> ConstVector(const std::vector<T>& vec, values_info vt) {
-        auto friendly_name = vt.to_string() + vec2str(vec);
+        auto friendly_name = vt.to_string() + vec2str(vec, 9);
         auto pnode = std::make_shared<GenericPattern>();
         pnode->set_friendly_name(friendly_name);
         pnode->set_predicate([vec, vt, friendly_name](const Output<Node>& value) {

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -15,6 +15,10 @@
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#include <cstdlib>
+#endif
+
 namespace ov {
 namespace intel_cpu {
 
@@ -333,7 +337,11 @@ struct PlainTensor : public PlainTensorBase {
         if (!data) {
             auto capacity_new = m_strides[0] * m_dims[0] * sizeof(DT);
             if (capacity_new > m_capacity) {
-                m_ptr = aligned_alloc(64, capacity_new);
+                #ifdef _WIN32
+                    m_ptr = _aligned_malloc(capacity_new, 64);
+                #else
+                    m_ptr = aligned_alloc(64, capacity_new);
+                #endif
                 m_capacity = capacity_new;
             }
         } else {


### PR DESCRIPTION
### Details:
This PR aim to fix windows build error on ADL
- fix int <-> size_t narrow conversion issue
- fix aligned_alloc not found in windows issue
- fix ambiguous call to str2vect function
